### PR TITLE
Add why we chose docusaurus DR

### DIFF
--- a/decision-records/DR-0001-why-docusaurus.md
+++ b/decision-records/DR-0001-why-docusaurus.md
@@ -2,7 +2,7 @@
 
 | Status      | implemented                                                                             |
 | :---------- | :-------------------------------------------------------------------------------------- |
-| **PR #**    | [2](https://github.com/blindnet-io/blindnet-docs/issues/2)                              |
+| **PR #**    | [6](https://github.com/blindnet-io/blindnet-docs/issues/6)                              |
 | **Author**  | Marko Stakic (marko@blindnet.io)                                                        |
 | **Reviwer** | Noël Macé (noel@blindnet.io)                                                            |
 

--- a/decision-records/DR-0001-why-docusaurus.md
+++ b/decision-records/DR-0001-why-docusaurus.md
@@ -1,0 +1,115 @@
+# Why we use Docusaurus
+
+| Status      | implemented                                                                             |
+| :---------- | :-------------------------------------------------------------------------------------- |
+| **PR #**    | [2](https://github.com/blindnet-io/blindnet-docs/issues/2)                              |
+| **Author**  | Marko Stakic (marko@blindnet.io)                                                        |
+| **Reviwer** | Noël Macé (noel@blindnet.io)                                                            |
+
+## Context and Problem Statement
+
+Blindnet devkit is a project aimed to developers and needs an appropriate documentation. There are multiple OSS engines to render the static documentation websites and we are exploring the best suited one.
+
+## Decision Drivers
+
+Since the devkit has implementations in multiple programming languages, having content tabs component (tab per language) is crucial.
+
+Other drivers:
+- what features are available
+- ease of use
+- customization capabilities
+- look and UX
+
+## Considered Options
+
+- [Docusaurus](https://docusaurus.io)
+- [MkDocs](https://www.mkdocs.org)
+- [Rocket](https://rocket.modern-web.dev)
+- [docsify](https://docsify.js.org)
+- [mdBook](https://rust-lang.github.io/mdBook)
+- [GitBook](https://www.gitbook.com)
+- [Read the Docs](https://readthedocs.org)
+
+## Decision Outcome
+
+Docusaurus is for us the best suited project for rendering documentation. It is superior in terms of easiness of use, feature richness, overall look and has a large community of users and maintainers.
+
+## Pros and Cons of the Options
+
+### Docusaurus
+
+#### pros
+- docs can be written in both Markdown and [React](https://reactjs.org)
+- large community
+- feature rich
+- beautiful theme and modern look
+- integration with [Algolia](https://www.algolia.com) for searching the docs
+
+#### cons
+- only one theme
+- not so great plugins for offline search
+
+### MkDocs
+
+#### pros
+- feature rich
+- lot of themes (e.g. [material](https://squidfunk.github.io/mkdocs-material)
+- good community and a lot of plugins
+
+#### cons
+- changing the theme and adding custom HTML/CSS is cumbersome
+- outdated look
+
+### Rocket
+
+#### cons
+- their website didn't work well, some blocks were not rendering in Firefox
+- maintenance issues
+- general static site builder, not specialised for documentation
+
+### docsify
+
+#### pros
+- easily customizable with Markdown and [Vue](https://vuejs.org)
+
+#### cons
+- no native content tabs (plugin for content tabs looks awkward)
+- less features than other options
+- simplistic result
+
+### mdBook
+
+#### pros
+- good local search engine
+- native executable code blocks for [Rust](https://www.rust-lang.org)
+
+#### cons
+- made specifically for Rust
+- no content tabs
+
+### GitBook
+
+#### pros
+- easy to set-up
+- integration with third party services (Slack, Github, etc.)
+- feature rich
+- beautiful, modern look
+
+#### cons
+- premium product
+
+### Read the Docs
+
+#### pros
+- easy to use
+
+#### cons
+- suited for smaller projects
+- outdated look
+- lacks features
+
+## Links
+
+- a part of [update docs epic](https://github.com/blindnet-io/communication-management/issues/14)
+
+<!-- markdownlint-disable-file MD013 -->

--- a/decision-records/DR-0001-why-docusaurus.md
+++ b/decision-records/DR-0001-why-docusaurus.md
@@ -3,8 +3,8 @@
 | Status      | implemented                                                                             |
 | :---------- | :-------------------------------------------------------------------------------------- |
 | **PR #**    | [6](https://github.com/blindnet-io/blindnet-docs/issues/6)                              |
-| **Author**  | Marko Stakic (marko@blindnet.io)                                                        |
-| **Reviwer** | Noël Macé (noel@blindnet.io)                                                            |
+| **Author** & **Sponsor** | Marko Stakic (marko@blindnet.io)                                                        |
+| **Lead Reviewer** | Noël Macé (noel@blindnet.io)                                                            |
 
 ## Context and Problem Statement
 

--- a/decision-records/DR-0001-why-docusaurus.md
+++ b/decision-records/DR-0001-why-docusaurus.md
@@ -3,12 +3,14 @@
 | Status      | implemented                                                                             |
 | :---------- | :-------------------------------------------------------------------------------------- |
 | **PR #**    | [6](https://github.com/blindnet-io/blindnet-docs/issues/6)                              |
-| **Author** & **Sponsor** | Marko Stakic (marko@blindnet.io)                                                        |
-| **Lead Reviewer** | Noël Macé (noel@blindnet.io)                                                            |
+| **Author** & **Sponsor** | Marko Stakic (marko@blindnet.io)                                           |
+| **Lead Reviewer** | Noël Macé (noel@blindnet.io)                                                      |
 
 ## Context and Problem Statement
 
-Blindnet devkit is a project aimed to developers and needs an appropriate documentation. There are multiple OSS engines to render the static documentation websites and we are exploring the best suited one.
+As specified in [this epic](https://github.com/blindnet-io/communication-management/issues/14), documentaion pages created in [MkDocs](https://www.mkdocs.org) [Material](https://squidfunk.github.io/mkdocs-material/) theme look outdated and its customization is cumbersome.
+
+Which OSS documentation rendering engine offers the [needed feature set](https://github.com/blindnet-io/communication-management/issues/63#issuecomment-1080364433) as well as a better look and feel without requiring important changes in the doc itself?
 
 ## Decision Drivers
 
@@ -23,7 +25,6 @@ Other drivers:
 ## Considered Options
 
 - [Docusaurus](https://docusaurus.io)
-- [MkDocs](https://www.mkdocs.org)
 - [Rocket](https://rocket.modern-web.dev)
 - [docsify](https://docsify.js.org)
 - [mdBook](https://rust-lang.github.io/mdBook)
@@ -48,17 +49,6 @@ Docusaurus is for us the best suited project for rendering documentation. It is 
 #### cons
 - only one theme
 - not so great plugins for offline search
-
-### MkDocs
-
-#### pros
-- feature rich
-- lot of themes (e.g. [material](https://squidfunk.github.io/mkdocs-material)
-- good community and a lot of plugins
-
-#### cons
-- changing the theme and adding custom HTML/CSS is cumbersome
-- outdated look
 
 ### Rocket
 
@@ -110,6 +100,6 @@ Docusaurus is for us the best suited project for rendering documentation. It is 
 
 ## Links
 
-- a part of [update docs epic](https://github.com/blindnet-io/communication-management/issues/14)
+- implemented in the [PR](https://github.com/blindnet-io/blindnet-docs/issues/6)
 
 <!-- markdownlint-disable-file MD013 -->

--- a/decision-records/DR-0001-why-docusaurus.md
+++ b/decision-records/DR-0001-why-docusaurus.md
@@ -86,7 +86,10 @@ Docusaurus is for us the best suited project for rendering documentation. It is 
 - beautiful, modern look
 
 #### cons
-- premium product
+- premium subscription required (paid per team member)
+
+Free community tier can be requested if certain conditions are [met](https://docs.gitbook.com/pricing/plans/non-profit-and-open-source-discounts).  
+We might consider GitBook in the future since it provides tools for collaborative editing, commenting, simple deployments and integration with many third party services.
 
 ### Read the Docs
 


### PR DESCRIPTION
Related [issue](https://github.com/blindnet-io/communication-management/issues/62).

A part of the [epic](https://github.com/blindnet-io/communication-management/issues/14) to improve the documentation of the blindnet devkit.

After discussion and evaluation of existing docs rendering engines, we decided to go with [Docusaurus](https://docusaurus.io/).
This PR adds the decision record.